### PR TITLE
Add an example of a daily trigger at 11:00 AM

### DIFF
--- a/src/docs/comparisonWithQuartzPlugin.adoc
+++ b/src/docs/comparisonWithQuartzPlugin.adoc
@@ -150,5 +150,9 @@ void buildTriggers() {
    triggers << factory('run every day one second before midnight')
          .startAt(todayAt(23,59,59))
          .intervalInDays(1).build()
+         
+   triggers << factory('run every day at 11:00 AM')
+         .startAt( todayAt(11,00,00).before(new Date()) ? tomorrowAt(11,00,00) : todayAt(11,00,00) )
+         .intervalInDays(1).build()
 }
 ----


### PR DESCRIPTION
If you want to configure a trigger every day at 11:00 AM. You may mistakenly go with:

```
 triggers << factory('run every day one at 11:00 AM')
         .startAt(todayAt(11,00,00))
         .intervalInDays(1).build()
```

This will cause the trigger to fire if you startup the application at 11:15 AM. It logs:

`ERROR com.agileorbit.schwartz.listener.ProgressTrackingListener - No JobRunInfo found for Trigger DEFAULT.run every day one at 11:00 AM in triggerMisfired`

What you want to do it is schedule the trigger start for tomorrow if you are starting the application after the intended time of the day. I add such an example to the docs.