### PR TITLE
Fixed #8 by doing nothing with the ApplicationContext

### DIFF
--- a/src/main/groovy/com/agileorbit/schwartz/SchwartzGrailsPlugin.groovy
+++ b/src/main/groovy/com/agileorbit/schwartz/SchwartzGrailsPlugin.groovy
@@ -67,6 +67,11 @@ class SchwartzGrailsPlugin extends Plugin {
 	}}
 
 	void doWithApplicationContext() {
+		if (!grailsApplication.config.getProperty('quartz.pluginEnabled', Boolean, true)) {
+			log.info 'Not initializing, quartz.pluginEnabled is false'
+			return
+		}
+
 		applicationContext.getBean('quartzJobFactory', SchwartzJobFactory).init()
 
 		applicationContext.getBean('quartzService', QuartzService).init()


### PR DESCRIPTION
I fixed #8 by doing skipping initializing the `quartzJobFactory` and `quartzService` in the `doWithApplicationContext` when `pluginEnabled == false`