### PR TITLE
Added a cleanup section to an integration test.

### DIFF
--- a/integration-test-app/src/integration-test/groovy/com/agileorbit/schwartz/test/SchwartzJobFactoryIntegrationSpec.groovy
+++ b/integration-test-app/src/integration-test/groovy/com/agileorbit/schwartz/test/SchwartzJobFactoryIntegrationSpec.groovy
@@ -174,6 +174,14 @@ class SchwartzJobFactoryIntegrationSpec extends AbstractQuartzSpec {
 		otherStringValue == jobResult.otherStringValueFromMergedData
 
 		jobInstance
+
+        cleanup:
+        // Remove the listeners used in this test to prevent the from polluting
+        // other tests using the same quartz scheduler
+        // (example ConfigValidationSpec.check configured global listeners)
+        quartzScheduler.listenerManager.removeJobListener 'SchwartzJobFactoryIntegrationSpec'
+        quartzScheduler.listenerManager.removeSchedulerListener listeners
+        quartzScheduler.listenerManager.removeTriggerListener 'SchwartzJobFactoryIntegrationSpec'
 	}
 
 	private TriggerFiredBundle createTriggerFiredBundle(JobDetail jobDetail, OperableTrigger trigger) {


### PR DESCRIPTION
The cleanup removes scheduler listeners that were added/used for this
particular test but polluted the scheduler for another test.