### PR TITLE
Made the dataSource optionally autowired in QuartzService.

### DIFF
--- a/schwartz/grails-app/services/com/agileorbit/schwartz/QuartzService.groovy
+++ b/schwartz/grails-app/services/com/agileorbit/schwartz/QuartzService.groovy
@@ -47,7 +47,7 @@ import static org.quartz.impl.matchers.GroupMatcher.anyGroup
 @Transactional
 class QuartzService {
 
-	@Autowired protected DataSource dataSource
+	@Autowired(required=false) protected DataSource dataSource
 	@Autowired protected GrailsApplication grailsApplication
 	@Autowired protected Scheduler quartzScheduler
 	@Autowired protected SessionBinderJobListener sessionBinderJobListener


### PR DESCRIPTION
This makes the plugin work in applications without a defined hibernate dataSource (for example an application with mongodb).